### PR TITLE
Decreases CodeMirror's font size

### DIFF
--- a/web/css/hydra.css
+++ b/web/css/hydra.css
@@ -145,10 +145,6 @@ span.lir-env, span.lir-map { display: none; }
   color: #9B59B6;
 }
 
-.CodeMirror {
-  font-size: 16pt;
-}
-
 .popover.deopt > .popover-content > pre {
   font-size: 0.7em;
 }


### PR DESCRIPTION
From 16pt to 14px

Before:
![source 2014-03-16 00-16-42 2014-03-16 00-16-45](https://f.cloud.github.com/assets/1131196/2430188/c8ffb1a0-acc1-11e3-8b88-e50b1cfa6feb.jpg)

After:
![index html source 2014-03-16 00-15-23 2014-03-16 00-15-26](https://f.cloud.github.com/assets/1131196/2430182/9a3b953c-acc1-11e3-9ae0-73cf22c54137.jpg)
