### PR TITLE
Add artifact loading from gists

### DIFF
--- a/irhydra/lib/src/ui/hydra.dart
+++ b/irhydra/lib/src/ui/hydra.dart
@@ -150,6 +150,14 @@ class HydraElement extends PolymerElement {
   static final DRIVE_REGEXP = new RegExp(r"^drive:([_\w.]+)$");
   static const DRIVE_ROOT = 'http://googledrive.com/host/0B6XwArTFTLptOWZfVTlUWkdkMTg/';
 
+  static final GIST_REGEXP = new RegExp(r"^gist:([^\W_]+(?:-[^\W_]+)*)/([a-f0-9]+)$");
+  static const GIST_ROOT = 'https://gist.githubusercontent.com/';
+
+  _createGistArtifacts(username, id) => [
+    "${GIST_ROOT}${username}/${id}/raw/hydrogen.cfg",
+    "${GIST_ROOT}${username}/${id}/raw/code.asm"
+  ];
+
   _loadDemo(fragment) {
     if (DEMOS.containsKey(fragment)) {
       _wait(DEMOS[fragment], _requestArtifact);
@@ -159,6 +167,13 @@ class HydraElement extends PolymerElement {
     final driveMatch = DRIVE_REGEXP.firstMatch(fragment);
     if (driveMatch != null) {
       _wait(["${DRIVE_ROOT}${driveMatch.group(1)}"], _requestArtifact);
+      return true;
+    }
+
+    // Load artifacts from gist when fragment matches 'gist:username/gistId'.
+    final gistMatch = GIST_REGEXP.firstMatch(fragment);
+    if (gistMatch != null) {
+      _wait(_createGistArtifacts(gistMatch.group(1), gistMatch.group(2)), _requestArtifact);
       return true;
     }
 

--- a/irhydra/lib/src/ui/hydra.dart
+++ b/irhydra/lib/src/ui/hydra.dart
@@ -150,13 +150,8 @@ class HydraElement extends PolymerElement {
   static final DRIVE_REGEXP = new RegExp(r"^drive:([_\w.]+)$");
   static const DRIVE_ROOT = 'http://googledrive.com/host/0B6XwArTFTLptOWZfVTlUWkdkMTg/';
 
-  static final GIST_REGEXP = new RegExp(r"^gist:([^\W_]+(?:-[^\W_]+)*)/([a-f0-9]+)$");
-  static const GIST_ROOT = 'https://gist.githubusercontent.com/';
-
-  _createGistArtifacts(username, id) => [
-    "${GIST_ROOT}${username}/${id}/raw/hydrogen.cfg",
-    "${GIST_ROOT}${username}/${id}/raw/code.asm"
-  ];
+  static final GIST_REGEXP = new RegExp(r"^gist:([a-f0-9]+)$");
+  static const GIST_ROOT = 'https://gist.githubusercontent.com/raw/';
 
   _loadDemo(fragment) {
     if (DEMOS.containsKey(fragment)) {
@@ -170,10 +165,13 @@ class HydraElement extends PolymerElement {
       return true;
     }
 
-    // Load artifacts from gist when fragment matches 'gist:username/gistId'.
+    // Load artifacts from gist when fragment matches 'gist:gistId'.
     final gistMatch = GIST_REGEXP.firstMatch(fragment);
     if (gistMatch != null) {
-      _wait(_createGistArtifacts(gistMatch.group(1), gistMatch.group(2)), _requestArtifact);
+      _wait([
+        "${GIST_ROOT}${gistMatch.group(1)}/hydrogen.cfg",
+        "${GIST_ROOT}${gistMatch.group(1)}/code.asm"
+      ], _requestArtifact);
       return true;
     }
 


### PR DESCRIPTION
I've wanted to be able to share irhydra views via URL for some time. When I went in there today to see the feasibility of this, I noticed you had already added support for loading from a Drive account, so rather than filing an issue I just adapted that code to load from gists, as long as the gist has a `hydrogen.cfg` and a `code.asm` file.

Not sure if you had plans around loading files, and I haven't written any Dart in about 2 years, so feel free to close this PR without hurting my feelings :)

I put up a demo on my fork. The artifacts in
https://gist.github.com/brendankenny/75d281c83d98d7f0e070
are loaded by adding `#gist:brendankenny/75d281c83d98d7f0e070` to the URL. [Demo Page](https://brendankenny.github.io/irhydra/#gist:brendankenny/75d281c83d98d7f0e070)