### PR TITLE
set default to crankshaft after parsing.

### DIFF
--- a/irhydra/lib/src/modes/v8/code_parser.dart
+++ b/irhydra/lib/src/modes/v8/code_parser.dart
@@ -69,6 +69,18 @@ class PreParser extends parsing.ParserBase {
 
   PreParser(text, this.timeline, this.statusObject) : super(text.split('\n'));
 
+  parse() {
+    super.parse();
+    for (var i = 0; i < methods.length; i++) {
+      var method = methods[i];
+      if (!method.isTagged("turbofan") &&
+          !method.isTagged("crankshaft")) {
+        // People of the past knew one and only compiler.
+        method.tag("crankshaft");
+      }
+    }
+  }
+
   enterMethod(name, optimizationId) {
     if (currentMethod != null && currentMethod.optimizationId == optimizationId) {
       return;
@@ -118,9 +130,6 @@ class PreParser extends parsing.ParserBase {
           currentMethod.phases.add(new IR.Phase(currentMethod, "Z_Code generation", code: subrange()));
           if (!this.optCompiler.isEmpty) {
             currentMethod.tag(optCompiler.take());
-          } else {
-            // People of the past knew one and only compiler.
-            currentMethod.tag("crankshaft");
           }
           leaveMethod();
           // Leave this (instructions) and outer (code) states.


### PR DESCRIPTION
The splice code in IR (eye icon) button used to work with traces from the release Chrome (which does not support disassembly).  The current fix for this issue requires code have disassembly.

This change moves setting the default until after parse.
